### PR TITLE
Fix typo in Activity 1

### DIFF
--- a/Activity_1_Python_Basics.ipynb
+++ b/Activity_1_Python_Basics.ipynb
@@ -45,7 +45,7 @@
       "source": [
         "## Getting Started\n",
         "\n",
-        "Jupyter notebooks have two kids of cells.  \"Markdown\" cells, like this one which can contain formatted text, and \"Code\" cells, which contain the code you will run.\n",
+        "Jupyter notebooks have two kinds of cells.  \"Markdown\" cells, like this one which can contain formatted text, and \"Code\" cells, which contain the code you will run.\n",
         "\n",
         "To execute the code in a cell, you can either:\n",
         "* click the **Play** icon on the left\n",


### PR DESCRIPTION
"Jupyter notebooks have two **kids** of cells." -> "Jupyter notebooks have two **kinds** of cells."